### PR TITLE
[FLINK-30719] Add nodejs to docker image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -65,6 +65,9 @@ RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
 
 ENV MAVEN_HOME /usr/share/maven
 
+# Install NodeJS
+RUN ["bin/bash", "-c", "curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash && source ~/.nvm/nvm.sh && nvm install 16.13.2"]
+
 # Use UTF-8
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen ; locale-gen ; update-locale en_US.UTF-8
 ENV LC_ALL "en_US.UTF-8"


### PR DESCRIPTION
The idea is to use preinstalled nodejs of the same version as used in `flink-runtime-web` module to avoid cases when it is failed to download it correctly for instance https://issues.apache.org/jira/browse/FLINK-30719