### PR TITLE
[FLINK-34194][ci] Updates base image to Ubuntu 22.04

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -84,19 +84,6 @@ RUN mkdir -p /usr/share/hugo \
  && rm -f /tmp/hugo.tar.gz \
  && ln -s /usr/share/hugo/hugo /usr/bin/hugo
 
-# Install maven
-ARG MAVEN_VERSION=3.8.6
-ARG USER_HOME_DIR="/root"
-ARG BASE_URL=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/${MAVEN_VERSION}
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
-
-ENV MAVEN_HOME /usr/share/maven
-
 # Use UTF-8
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen ; locale-gen ; update-locale en_US.UTF-8
 ENV LC_ALL "en_US.UTF-8"

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -3,7 +3,30 @@ FROM ubuntu:xenial
 # install packages
 RUN set -eux; \
 	apt-get update; apt-get upgrade -y ; \
-	apt-get install -y gosu sudo locales make less build-essential openjdk-8-jdk libjemalloc-dev curl libapr1 unzip uuid-runtime jq bsdmainutils wget python docker.io psmisc software-properties-common apt-transport-https; \
+	apt-get install -y \
+		gosu \
+		sudo \
+		locales \
+		make \
+		less \
+		build-essential \
+		`# default JDK for Apache Flink` \
+		openjdk-8-jdk \
+		`# FLINK-18356` \
+		libjemalloc-dev \
+		curl \
+		libapr1 \
+		unzip \
+		uuid-runtime \
+		jq \
+		bsdmainutils \
+		wget \
+		`# for pyflink test suite` \
+		python \
+		docker.io \
+		psmisc \
+		software-properties-common \
+		apt-transport-https; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Install latest git

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		bsdmainutils \
 		wget \
 		`# for pyflink test suite` \
-		python \
+		python3 \
 		docker.io \
 		psmisc \
 		software-properties-common \
 		apt-transport-https; \
-	rm -rf /var/lib/apt/lists/*;
+	rm -rf /var/lib/apt/lists/*;\
+	# enables legacy python command for PyFlink tests
+	ln -s /usr/bin/python3 /usr/bin/python
 
 # Install latest git
 RUN set -eux; \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -89,3 +89,7 @@ RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen ; locale-gen ; update-locale en_U
 ENV LC_ALL "en_US.UTF-8"
 ENV LANG "en_US.UTF-8"
 ENV LANGUAGE "en_US.UTF-8"
+
+# Install OpenSSL version that's required by netty-tcnative
+RUN wget -r --no-parent -nd --accept=libssl1.0.0_*ubuntu5.*_amd64.deb http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/
+RUN apt install ./libssl1.0.0_*.deb

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:22.04
 
 # install packages
 RUN set -eux; \


### PR DESCRIPTION
The image is already pushed to DockerHub under `mapohl/flink-ci:FLINK-34914`