### PR TITLE
[FLINK-36801][ci] Update base image to Ubuntu Jammy (22.04)

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:xenial
+FROM ubuntu:jammy
 
 # install packages
 RUN set -eux; \
 	apt-get update; apt-get upgrade -y ; \
-	apt-get install -y gosu sudo locales make less build-essential openjdk-8-jdk libjemalloc-dev curl libapr1 unzip uuid-runtime jq bsdmainutils wget python docker.io psmisc software-properties-common apt-transport-https; \
+	apt-get install -y gosu sudo locales make less build-essential openjdk-8-jdk libjemalloc-dev curl libapr1 unzip uuid-runtime jq bsdmainutils wget python3 docker.io psmisc software-properties-common apt-transport-https; \
 	rm -rf /var/lib/apt/lists/*;
 
 # Install latest git


### PR DESCRIPTION
This PR aims to just bump the version of Ubuntu to Jammy (22.04) without any additional changes (just python3 instead of python since it's not there anymore) to be able to run NodeJS 18+ since it requires `GLIBC_2.28` which is available from Ubuntu 20.04 and use the new image in build CI.
I have rebased my master to remove the commits by [Matthias Pohl](https://github.com/XComp) to have just Ubuntu 22.04 as suggested by Ferenc Csaky in his comment in https://issues.apache.org/jira/browse/FLINK-36739
The image is already pushed to DockerHub under mehdid1993/flink-ci:FLINK-36801
The image is used in the PR https://github.com/apache/flink/pull/25670 as a test and this PR will evolve depending on the discussions
